### PR TITLE
Resume queued and interrupted operations across launches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,10 +560,13 @@ version = "0.1.4"
 dependencies = [
  "anyhow",
  "crossterm",
+ "directories",
  "futures",
  "nixbox-config",
  "nixbox-nix",
  "ratatui",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tui-input",

--- a/crates/nixbox-nix/src/build.rs
+++ b/crates/nixbox-nix/src/build.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use anyhow::{Context, Result};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command;
 use tokio::sync::mpsc;
 
@@ -31,7 +31,10 @@ pub fn home_manager_switch_cmd(config_dir: &Path) -> (String, Vec<String>) {
     let user = std::env::var("USER").unwrap_or_else(|_| "user".into());
     let flake_ref = format!("{}#{}", config_dir.display(), user);
     if let Some(bin) = find_in_nix_profiles("home-manager") {
-        (bin.to_string_lossy().into_owned(), vec!["switch".into(), "--flake".into(), flake_ref])
+        (
+            bin.to_string_lossy().into_owned(),
+            vec!["switch".into(), "--flake".into(), flake_ref],
+        )
     } else {
         (
             "nix".into(),
@@ -77,7 +80,12 @@ pub fn nixos_rebuild_switch_cmd(config_dir: &Path) -> (String, Vec<String>) {
     let flake_ref = format!("{}#nixos", config_dir.display());
     (
         "sudo".into(),
-        vec!["nixos-rebuild".into(), "switch".into(), "--flake".into(), flake_ref],
+        vec![
+            "nixos-rebuild".into(),
+            "switch".into(),
+            "--flake".into(),
+            flake_ref,
+        ],
     )
 }
 
@@ -98,18 +106,8 @@ pub async fn rebuild(command: &str, args: &[&str], tx: mpsc::Sender<BuildEvent>)
     let stdout_tx = tx.clone();
     let stderr_tx = tx.clone();
 
-    let stdout_task = tokio::spawn(async move {
-        let mut reader = BufReader::new(stdout).lines();
-        while let Ok(Some(line)) = reader.next_line().await {
-            let _ = stdout_tx.send(BuildEvent::Line(line)).await;
-        }
-    });
-    let stderr_task = tokio::spawn(async move {
-        let mut reader = BufReader::new(stderr).lines();
-        while let Ok(Some(line)) = reader.next_line().await {
-            let _ = stderr_tx.send(BuildEvent::Line(line)).await;
-        }
-    });
+    let stdout_task = tokio::spawn(forward_output(stdout, stdout_tx));
+    let stderr_task = tokio::spawn(forward_output(stderr, stderr_tx));
 
     let status = child.wait().await?;
     let _ = stdout_task.await;
@@ -126,4 +124,53 @@ pub async fn rebuild(command: &str, args: &[&str], tx: mpsc::Sender<BuildEvent>)
     };
     let _ = tx.send(BuildEvent::Finished(result)).await;
     Ok(())
+}
+
+async fn forward_output<R>(stream: R, tx: mpsc::Sender<BuildEvent>)
+where
+    R: AsyncRead + Unpin,
+{
+    let mut reader = BufReader::new(stream).lines();
+    while let Ok(Some(line)) = reader.next_line().await {
+        let text = line.trim_end().to_string();
+        if text.is_empty() {
+            continue;
+        }
+        if tx.send(BuildEvent::Line(text)).await.is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BuildEvent, forward_output, nixos_rebuild_switch_cmd};
+    use tokio::io::{AsyncWriteExt, duplex};
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn forwards_newline_delimited_lines() {
+        let (mut writer, reader) = duplex(128);
+        let (tx, mut rx) = mpsc::channel(8);
+        let task = tokio::spawn(forward_output(reader, tx));
+
+        writer.write_all(b"first line\nsecond line\n").await.unwrap();
+        drop(writer);
+        task.await.unwrap();
+
+        assert!(matches!(rx.recv().await, Some(BuildEvent::Line(line)) if line == "first line"));
+        assert!(matches!(rx.recv().await, Some(BuildEvent::Line(line)) if line == "second line"));
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[test]
+    fn nixos_rebuild_uses_sudo_with_flake_ref() {
+        let (cmd, args) = nixos_rebuild_switch_cmd(std::path::Path::new("/tmp/nixbox-config"));
+
+        assert_eq!(cmd, "sudo");
+        assert_eq!(args[0], "nixos-rebuild");
+        assert_eq!(args[1], "switch");
+        assert_eq!(args[2], "--flake");
+        assert_eq!(args[3], "/tmp/nixbox-config#nixos");
+    }
 }

--- a/crates/nixbox-nix/src/build.rs
+++ b/crates/nixbox-nix/src/build.rs
@@ -133,9 +133,6 @@ where
     let mut reader = BufReader::new(stream).lines();
     while let Ok(Some(line)) = reader.next_line().await {
         let text = line.trim_end().to_string();
-        if text.is_empty() {
-            continue;
-        }
         if tx.send(BuildEvent::Line(text)).await.is_err() {
             break;
         }

--- a/crates/nixbox-nix/src/search.rs
+++ b/crates/nixbox-nix/src/search.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchHit {
     pub attr: String,
     pub pname: String,

--- a/crates/nixbox-tui/Cargo.toml
+++ b/crates/nixbox-tui/Cargo.toml
@@ -21,3 +21,6 @@ tui-input = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+directories = { workspace = true }

--- a/crates/nixbox-tui/src/app.rs
+++ b/crates/nixbox-tui/src/app.rs
@@ -22,7 +22,10 @@ use ratatui::Terminal;
 use tokio::sync::mpsc;
 use tui_input::Input;
 
+use serde::{Deserialize, Serialize};
+
 use crate::handlers::{handle_app_event, handle_terminal_event};
+use crate::state::{self, InProgress, PersistedState};
 use crate::theme;
 use crate::ui;
 
@@ -35,7 +38,7 @@ pub(crate) enum Mode {
     ChannelEdit,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum QueuedOp {
     Install { hit: SearchHit, scope: Target },
     Uninstall { name: String, scope: Target },
@@ -141,6 +144,13 @@ pub(crate) struct App {
     pub(crate) spinner_frame: usize,
     pub(crate) queue: VecDeque<QueuedOp>,
     pub(crate) current_op_label: Option<String>,
+    /// Set while a rebuild is in flight; mirrors what gets persisted so the
+    /// next launch can detect an interrupted operation. Cleared when the
+    /// rebuild finishes (success or failure).
+    pub(crate) in_progress_op: Option<InProgress>,
+    /// Error message from the previous run that was never acknowledged.
+    /// Survives across launches until the next successful build clears it.
+    pub(crate) last_error: Option<String>,
     pub(crate) channel_cursor: usize,
 }
 
@@ -188,6 +198,8 @@ impl App {
             spinner_frame: 0,
             queue: VecDeque::new(),
             current_op_label: None,
+            in_progress_op: None,
+            last_error: None,
             channel_cursor: 0,
         }
     }
@@ -303,6 +315,18 @@ impl App {
         }
     }
 
+    /// Writes the current persistable slice of state to disk so the next
+    /// launch can recover from a crash, kill, or interrupted rebuild. Errors
+    /// are swallowed because failing to persist must never break the TUI.
+    pub(crate) fn persist(&self) {
+        let snapshot = PersistedState {
+            pending_queue: self.queue.iter().cloned().collect(),
+            in_progress: self.in_progress_op.clone(),
+            last_error: self.last_error.clone(),
+        };
+        let _ = snapshot.save();
+    }
+
     /// Re-reads both main config files and refreshes `external_packages`,
     /// excluding anything already tracked in either manifest.
     pub(crate) fn refresh_external_packages(&mut self) {
@@ -392,6 +416,7 @@ async fn event_loop(
 ) -> Result<()> {
     let mut app = App::new(config, home_manifest, nixos_manifest, externals);
     let (tx, mut rx) = mpsc::channel::<AppEvent>(128);
+    state::restore(&mut app, &tx);
     let mut term_events = EventStream::new();
     let mut spinner_tick = tokio::time::interval(Duration::from_millis(80));
     spinner_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/crates/nixbox-tui/src/handlers.rs
+++ b/crates/nixbox-tui/src/handlers.rs
@@ -219,13 +219,21 @@ pub(crate) fn handle_app_event(app: &mut App, tx: &mpsc::Sender<AppEvent>, ev: A
         AppEvent::Build(BuildEvent::Finished(result)) => {
             let label = app.current_op_label.take().unwrap_or_else(|| "build".into());
             app.build_in_progress = false;
-            app.status = match &result {
-                Ok(()) => format!("{} done.", label),
-                Err(err) => format!("{} failed: {}.", label, err),
-            };
+            app.in_progress_op = None;
+            match &result {
+                Ok(()) => {
+                    app.status = format!("{} done.", label);
+                    app.last_error = None;
+                }
+                Err(err) => {
+                    app.status = format!("{} failed: {}.", label, err);
+                    app.last_error = Some(format!("{}: {}", label, err));
+                }
+            }
             if result.is_ok() {
                 app.refresh_external_packages();
             }
+            app.persist();
             drain_queue(app, tx);
             if !app.visible_tabs().contains(&app.tab) {
                 app.tab = Tab::Search;

--- a/crates/nixbox-tui/src/lib.rs
+++ b/crates/nixbox-tui/src/lib.rs
@@ -2,6 +2,7 @@ mod app;
 mod handlers;
 mod nav;
 mod ops;
+mod state;
 mod theme;
 mod ui;
 

--- a/crates/nixbox-tui/src/ops.rs
+++ b/crates/nixbox-tui/src/ops.rs
@@ -14,6 +14,7 @@ use tokio::sync::mpsc;
 use tokio::time::sleep;
 
 use crate::app::{App, AppEvent, InstalledCursor, QueuedOp, Tab};
+use crate::state::InProgress;
 
 fn scope_to_scan_target(scope: Target) -> ScanTarget {
     match scope {
@@ -109,8 +110,13 @@ pub(crate) fn spawn_rebuild(
 ) {
     app.build_in_progress = true;
     app.current_op_label = Some(action_label.clone());
+    app.in_progress_op = Some(InProgress {
+        scope,
+        label: action_label.clone(),
+    });
     app.log.clear();
     app.status = format!("{}...", action_label);
+    app.persist();
 
     let config_dir = app.config.home_manager_dir();
     let app_tx = tx.clone();
@@ -167,11 +173,15 @@ pub(crate) fn drain_queue(app: &mut App, tx: &mpsc::Sender<AppEvent>) {
     if app.build_in_progress {
         return;
     }
-    let Some(op) = app.queue.pop_front() else { return };
+    let Some(op) = app.queue.pop_front() else {
+        app.persist();
+        return;
+    };
     let label = op.label();
     let scope = op.scope();
     if let Err(e) = apply_op_to_manifest(app, &op) {
         app.status = format!("{}: failed to write manifest: {}", label, e);
+        app.persist();
         drain_queue(app, tx);
         return;
     }
@@ -258,6 +268,7 @@ pub(crate) async fn install_selected(app: &mut App, tx: &mpsc::Sender<AppEvent>)
 
     let attr = hit.attr.clone();
     app.queue.push_back(QueuedOp::Install { hit, scope });
+    app.persist();
     if app.build_in_progress {
         app.status = format!("Queued install: {}.", attr);
         app.tab = Tab::Queue;
@@ -304,6 +315,7 @@ pub(crate) async fn uninstall_selected(
         name: name.clone(),
         scope,
     });
+    app.persist();
     if app.build_in_progress {
         app.status = format!("Queued remove: {} [{}].", name, scope.tag());
         app.tab = Tab::Queue;
@@ -352,6 +364,7 @@ pub(crate) async fn migrate_selected(app: &mut App, tx: &mpsc::Sender<AppEvent>)
         names: vec![name.clone()],
         scope,
     });
+    app.persist();
     if app.build_in_progress {
         app.status = format!("Queued migrate: {} [{}].", name, scope.tag());
         app.tab = Tab::Queue;
@@ -392,6 +405,7 @@ pub(crate) async fn migrate_all(app: &mut App, tx: &mpsc::Sender<AppEvent>) -> R
             scope: Target::NixosSystem,
         });
     }
+    app.persist();
     let summary = format!(
         "Queued migrate-all ({} hm, {} nixos).",
         hm_count, nx_count,

--- a/crates/nixbox-tui/src/state.rs
+++ b/crates/nixbox-tui/src/state.rs
@@ -1,0 +1,178 @@
+//! Persistence for the bits of TUI state that must survive a crash or kill:
+//! the pending queue, the operation that was mid-flight (so we can re-run the
+//! interrupted rebuild), and the last error message.
+//!
+//! The manifest file on disk is written *before* `spawn_rebuild` runs, so if
+//! the rebuild gets killed mid-flight the manifest already reflects the
+//! intended change — recovery just means re-invoking the rebuild for that
+//! scope. Queued operations that hadn't reached the manifest yet are stored
+//! verbatim and re-processed normally on the next launch.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use directories::BaseDirs;
+use nixbox_config::Target;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use crate::app::{App, AppEvent, QueuedOp, Tab};
+use crate::ops::{drain_queue, spawn_rebuild};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct InProgress {
+    pub scope: Target,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct PersistedState {
+    #[serde(default)]
+    pub pending_queue: Vec<QueuedOp>,
+    #[serde(default)]
+    pub in_progress: Option<InProgress>,
+    #[serde(default)]
+    pub last_error: Option<String>,
+}
+
+impl PersistedState {
+    fn is_empty(&self) -> bool {
+        self.pending_queue.is_empty() && self.in_progress.is_none() && self.last_error.is_none()
+    }
+
+    pub(crate) fn load() -> Option<Self> {
+        let path = state_path().ok()?;
+        if !path.exists() {
+            return None;
+        }
+        let raw = fs::read_to_string(&path).ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    pub(crate) fn save(&self) -> Result<()> {
+        let path = state_path()?;
+        if self.is_empty() {
+            if path.exists() {
+                let _ = fs::remove_file(&path);
+            }
+            return Ok(());
+        }
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let raw = serde_json::to_string_pretty(self)?;
+        fs::write(&path, raw)
+            .with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+}
+
+pub(crate) fn state_path() -> Result<PathBuf> {
+    let base = BaseDirs::new().context("locating user directories")?;
+    Ok(base.config_dir().join("nixbox").join("state.json"))
+}
+
+/// Pulls any saved state from disk into `app` and kicks off whatever work
+/// remains: an interrupted rebuild is re-launched first, otherwise pending
+/// queued ops start draining immediately.
+pub(crate) fn restore(app: &mut App, tx: &mpsc::Sender<AppEvent>) {
+    let Some(saved) = PersistedState::load() else {
+        return;
+    };
+
+    if let Some(err) = saved.last_error.clone() {
+        app.last_error = Some(err.clone());
+        app.status = format!("Previous run failed: {}", err);
+    }
+
+    for op in saved.pending_queue {
+        app.queue.push_back(op);
+    }
+
+    if let Some(ip) = saved.in_progress {
+        // The manifest was already written for this op before it was killed —
+        // re-run the rebuild to actually apply it.
+        let label = format!("resume {}", ip.label);
+        app.tab = Tab::Building;
+        app.status = format!("Resuming interrupted build: {}.", ip.label);
+        spawn_rebuild(app, tx, ip.scope, label);
+    } else if !app.queue.is_empty() {
+        app.tab = Tab::Queue;
+        app.status = format!("Resuming {} queued op(s).", app.queue.len());
+        drain_queue(app, tx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InProgress, PersistedState};
+    use crate::app::QueuedOp;
+    use nixbox_config::Target;
+    use nixbox_nix::search::SearchHit;
+
+    fn hit(attr: &str) -> SearchHit {
+        SearchHit {
+            attr: attr.into(),
+            pname: attr.into(),
+            version: "0".into(),
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn queue_with_mixed_op_kinds_round_trips_through_json() {
+        let state = PersistedState {
+            pending_queue: vec![
+                QueuedOp::Install {
+                    hit: hit("ripgrep"),
+                    scope: Target::HomeManager,
+                },
+                QueuedOp::Uninstall {
+                    name: "fd".into(),
+                    scope: Target::NixosSystem,
+                },
+                QueuedOp::Migrate {
+                    names: vec!["git".into(), "neovim".into()],
+                    scope: Target::HomeManager,
+                },
+            ],
+            in_progress: Some(InProgress {
+                scope: Target::HomeManager,
+                label: "install ripgrep [hm]".into(),
+            }),
+            last_error: Some("install foo [hm]: nonzero exit".into()),
+        };
+
+        let json = serde_json::to_string(&state).expect("serialize");
+        let restored: PersistedState = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(restored.pending_queue.len(), 3);
+        assert!(matches!(
+            &restored.pending_queue[0],
+            QueuedOp::Install { hit, scope: Target::HomeManager } if hit.attr == "ripgrep"
+        ));
+        assert!(matches!(
+            &restored.pending_queue[1],
+            QueuedOp::Uninstall { name, scope: Target::NixosSystem } if name == "fd"
+        ));
+        assert!(matches!(
+            &restored.pending_queue[2],
+            QueuedOp::Migrate { names, scope: Target::HomeManager } if names == &vec!["git".to_string(), "neovim".to_string()]
+        ));
+        let ip = restored.in_progress.expect("in_progress preserved");
+        assert_eq!(ip.scope, Target::HomeManager);
+        assert_eq!(ip.label, "install ripgrep [hm]");
+        assert_eq!(
+            restored.last_error.as_deref(),
+            Some("install foo [hm]: nonzero exit"),
+        );
+    }
+
+    #[test]
+    fn empty_state_serializes_to_empty_fields() {
+        let state = PersistedState::default();
+        assert!(state.is_empty());
+    }
+}

--- a/crates/nixbox-tui/src/state.rs
+++ b/crates/nixbox-tui/src/state.rs
@@ -94,7 +94,11 @@ pub(crate) fn restore(app: &mut App, tx: &mpsc::Sender<AppEvent>) {
     if let Some(ip) = saved.in_progress {
         // The manifest was already written for this op before it was killed —
         // re-run the rebuild to actually apply it.
-        let label = format!("resume {}", ip.label);
+        let label = if ip.label.starts_with("resume ") {
+            ip.label.clone()
+        } else {
+            format!("resume {}", ip.label)
+        };
         app.tab = Tab::Building;
         app.status = format!("Resuming interrupted build: {}.", ip.label);
         spawn_rebuild(app, tx, ip.scope, label);

--- a/crates/nixbox-tui/src/state.rs
+++ b/crates/nixbox-tui/src/state.rs
@@ -175,7 +175,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_state_serializes_to_empty_fields() {
+    fn default_state_is_empty() {
         let state = PersistedState::default();
         assert!(state.is_empty());
     }

--- a/crates/nixbox-tui/src/ui/build.rs
+++ b/crates/nixbox-tui/src/ui/build.rs
@@ -1,10 +1,10 @@
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
-use ratatui::Frame;
 
-use crate::app::App;
 use super::titled_panel;
+use crate::app::App;
 
 pub(super) fn draw_build_body(f: &mut Frame, area: Rect, app: &App) {
     let t = app.theme();
@@ -13,8 +13,14 @@ pub(super) fn draw_build_body(f: &mut Frame, area: Rect, app: &App) {
         None => "Build output".to_string(),
     };
     let block = titled_panel(t, Span::styled(title, t.title_style()));
-    let log_height = area.height.saturating_sub(2) as usize;
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let log_height = inner.height as usize;
     let start = app.log.len().saturating_sub(log_height);
-    let text: Vec<Line> = app.log[start..].iter().map(|l| Line::from(l.clone())).collect();
-    f.render_widget(Paragraph::new(text).block(block), area);
+    let text: Vec<Line> = app.log[start..]
+        .iter()
+        .map(|l| Line::from(l.clone()))
+        .collect();
+    f.render_widget(Paragraph::new(text), inner);
 }


### PR DESCRIPTION
## Summary
- Persist the pending queue, the in-flight op, and the last error to ~/.config/nixbox/state.json on every state-changing event.
- On startup, queued ops drain in order and any rebuild that was killed mid-flight is re-invoked for its scope.
- Simplifies the Build tab to focus on the streaming log.

## Test plan
- [x] Queue several installs, quit mid-build, relaunch — interrupted op resumes and remaining queue drains in order.
- [x] Trigger a failing build, relaunch — previous error surfaces in the status line; next successful build clears it.
- [x] `cargo test --workspace` passes.