### PR TITLE
chore: bump version to v0.1.5 and add nixd/nil to flake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "nixbox"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "nixbox-config"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "directories",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "nixbox-nix"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "serde",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "nixbox-tui"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["Rajveer Singh"]
 license = "Apache-2.0"

--- a/crates/nixbox-tui/Cargo.toml
+++ b/crates/nixbox-tui/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 description = "Ratatui front-end (search/build views, theming) for the nixbox TUI."
 
 [dependencies]
-nixbox-nix = { path = "../nixbox-nix", version = "0.1.4" }
-nixbox-config = { path = "../nixbox-config", version = "0.1.4" }
+nixbox-nix = { path = "../nixbox-nix", version = "0.1.5" }
+nixbox-config = { path = "../nixbox-config", version = "0.1.5" }
 anyhow = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }

--- a/crates/nixbox/Cargo.toml
+++ b/crates/nixbox/Cargo.toml
@@ -16,9 +16,9 @@ name = "nixbox"
 path = "src/main.rs"
 
 [dependencies]
-nixbox-tui = { path = "../nixbox-tui", version = "0.1.4" }
-nixbox-nix = { path = "../nixbox-nix", version = "0.1.4" }
-nixbox-config = { path = "../nixbox-config", version = "0.1.4" }
+nixbox-tui = { path = "../nixbox-tui", version = "0.1.5" }
+nixbox-nix = { path = "../nixbox-nix", version = "0.1.5" }
+nixbox-config = { path = "../nixbox-config", version = "0.1.5" }
 anyhow = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
             packages = [
               rustToolchain
               pkgs.nix
+              pkgs.nixd
+              pkgs.nil
             ];
 
             RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";


### PR DESCRIPTION
## Summary
- Bump workspace version from `0.1.4` to `0.1.5` across all crates
- Add `nixd` and `nil` Nix language servers to the dev shell in `flake.nix`

## Test plan
- [ ] CI passes on merge
- [ ] Crates publish correctly at v0.1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)