### PR TITLE
Fix search relevance and add build cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "nixbox"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "nixbox-config"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "directories",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "nixbox-nix"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "libc",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "nixbox-tui"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ name = "nixbox-nix"
 version = "0.1.7"
 dependencies = [
  "anyhow",
+ "libc",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ tui-input = "0.10"
 clap = { version = "4.5", features = ["derive"] }
 directories = "5.0"
 futures = "0.3"
+libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 authors = ["Rajveer Singh"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Cargo workspace:
 | `d` / Delete       | uninstall selected (Installed tab)      |
 | `m`                | migrate selected external package       |
 | `M`                | migrate all migratable externals        |
+| `c`                | cancel active build (Building tab)      |
 | Tab / `l`          | next tab (Search → Installed → Build)   |
 | Shift-Tab / `h`    | previous tab                            |
 | Ctrl-T             | toggle home-manager / nixos target      |

--- a/crates/nixbox-nix/Cargo.toml
+++ b/crates/nixbox-nix/Cargo.toml
@@ -18,3 +18,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+libc = { workspace = true }

--- a/crates/nixbox-nix/src/build.rs
+++ b/crates/nixbox-nix/src/build.rs
@@ -1,15 +1,18 @@
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
-use tokio::process::Command;
-use tokio::sync::mpsc;
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::timeout;
 
 #[derive(Debug, Clone)]
 pub enum BuildEvent {
     Line(String),
     Finished(Result<(), String>),
+    Cancelled,
 }
 
 fn find_in_nix_profiles(name: &str) -> Option<PathBuf> {
@@ -92,15 +95,38 @@ pub fn nixos_rebuild_switch_cmd(config_dir: &Path) -> (String, Vec<String>) {
     )
 }
 
-pub async fn rebuild(command: &str, args: &[&str], tx: mpsc::Sender<BuildEvent>) -> Result<()> {
-    let resolved = find_in_nix_profiles(command).unwrap_or_else(|| PathBuf::from(command));
+pub async fn rebuild(
+    command_name: &str,
+    args: &[&str],
+    tx: mpsc::Sender<BuildEvent>,
+    mut cancel: oneshot::Receiver<()>,
+) -> Result<()> {
+    let resolved =
+        find_in_nix_profiles(command_name).unwrap_or_else(|| PathBuf::from(command_name));
 
-    let mut child = Command::new(&resolved)
+    let mut process = Command::new(&resolved);
+    process
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
-        .with_context(|| format!("spawning `{}` (resolved: {})", command, resolved.display()))?;
+        .kill_on_drop(true);
+    // Put wrappers such as sudo and every descendant they spawn in one group.
+    // This lets cancellation stop nixos-rebuild itself, not only its parent.
+    unsafe {
+        process.pre_exec(|| {
+            if libc::setpgid(0, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = process.spawn().with_context(|| {
+        format!(
+            "spawning `{}` (resolved: {})",
+            command_name,
+            resolved.display()
+        )
+    })?;
 
     let stdout = child.stdout.take().context("capturing stdout")?;
     let stderr = child.stderr.take().context("capturing stderr")?;
@@ -111,23 +137,55 @@ pub async fn rebuild(command: &str, args: &[&str], tx: mpsc::Sender<BuildEvent>)
     let stdout_task = tokio::spawn(forward_output(stdout, stdout_tx));
     let stderr_task = tokio::spawn(forward_output(stderr, stderr_tx));
 
-    let status = child.wait().await?;
+    let status = tokio::select! {
+        status = child.wait() => Some(status?),
+        _ = &mut cancel => {
+            terminate_process_group(&mut child).await?;
+            None
+        }
+    };
     let _ = stdout_task.await;
     let _ = stderr_task.await;
 
-    let result = if status.success() {
-        Ok(())
-    } else {
-        Err(format!(
+    let event = match status {
+        None => BuildEvent::Cancelled,
+        Some(status) if status.success() => BuildEvent::Finished(Ok(())),
+        Some(status) => BuildEvent::Finished(Err(format!(
             "{} exited with status {}",
-            command,
+            command_name,
             status
                 .code()
-                .map(|c| c.to_string())
-                .unwrap_or_else(|| "<signal>".into())
-        ))
+                .map_or_else(|| "<signal>".into(), |c| c.to_string())
+        ))),
     };
-    let _ = tx.send(BuildEvent::Finished(result)).await;
+    let _ = tx.send(event).await;
+    Ok(())
+}
+
+async fn terminate_process_group(child: &mut Child) -> Result<()> {
+    let Some(pid) = child.id() else {
+        return Ok(());
+    };
+    let group = -(pid as i32);
+    let term_result = unsafe { libc::kill(group, libc::SIGTERM) };
+    if term_result == -1 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::ESRCH) {
+            return Err(error).context("terminating rebuild process group");
+        }
+    }
+
+    match timeout(Duration::from_secs(3), child.wait()).await {
+        Ok(status) => {
+            status.context("reaping cancelled rebuild")?;
+        }
+        Err(_) => {
+            unsafe {
+                libc::kill(group, libc::SIGKILL);
+            }
+            child.wait().await.context("reaping cancelled rebuild")?;
+        }
+    }
     Ok(())
 }
 
@@ -148,7 +206,8 @@ where
 mod tests {
     use super::{BuildEvent, forward_output, nixos_rebuild_switch_cmd};
     use tokio::io::{AsyncWriteExt, duplex};
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio::time::{Duration, timeout};
 
     #[tokio::test]
     async fn forwards_newline_delimited_lines() {
@@ -177,5 +236,22 @@ mod tests {
         assert_eq!(args[1], "switch");
         assert_eq!(args[2], "--flake");
         assert_eq!(args[3], "/tmp/nixbox-config#nixos");
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_rebuild_and_emits_cancelled() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let task = tokio::spawn(super::rebuild("sh", &["-c", "sleep 30"], tx, cancel_rx));
+
+        tokio::task::yield_now().await;
+        cancel_tx.send(()).expect("send cancellation");
+
+        let event = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("rebuild should stop promptly")
+            .expect("build event");
+        assert!(matches!(event, BuildEvent::Cancelled));
+        task.await.expect("join rebuild").expect("cancel rebuild");
     }
 }

--- a/crates/nixbox-nix/src/search.rs
+++ b/crates/nixbox-nix/src/search.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::process::Stdio;
 
 use anyhow::{Context, Result};
-use serde::de::{Deserializer, IgnoredAny, MapAccess, Visitor};
+use serde::de::{Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
@@ -80,10 +80,7 @@ pub async fn search(channel: &str, query: &str) -> Result<Vec<SearchHit>> {
         anyhow::bail!("nix search failed: {}", stderr.trim());
     }
 
-    let mut hits = parse_hits(&stdout).context("parsing nix search JSON")?;
-
-    hits.sort_by(|a, b| a.pname.cmp(&b.pname));
-    Ok(hits)
+    parse_hits(&stdout, query).context("parsing nix search JSON")
 }
 
 async fn read_limited<R>(mut reader: R, max_bytes: usize) -> Result<Vec<u8>>
@@ -133,12 +130,29 @@ where
     Ok(out)
 }
 
-fn parse_hits(input: &[u8]) -> Result<Vec<SearchHit>, serde_json::Error> {
+fn parse_hits(input: &[u8], query: &str) -> Result<Vec<SearchHit>, serde_json::Error> {
     let mut deserializer = serde_json::Deserializer::from_slice(input);
-    deserializer.deserialize_map(SearchHitsVisitor)
+    deserializer.deserialize_map(SearchHitsVisitor {
+        query: ranking_term(query),
+    })
 }
 
-struct SearchHitsVisitor;
+struct SearchHitsVisitor {
+    query: String,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct Relevance {
+    tier: u8,
+    position: usize,
+    name_len: usize,
+    name: String,
+}
+
+struct RankedHit {
+    relevance: Relevance,
+    hit: SearchHit,
+}
 
 impl<'de> Visitor<'de> for SearchHitsVisitor {
     type Value = Vec<SearchHit>;
@@ -151,22 +165,90 @@ impl<'de> Visitor<'de> for SearchHitsVisitor {
     where
         A: MapAccess<'de>,
     {
-        let mut hits = Vec::new();
+        let mut hits: Vec<RankedHit> = Vec::new();
         while let Some(attr) = map.next_key::<String>()? {
+            let raw = map.next_value::<RawHit>()?;
+            let hit = SearchHit {
+                attr: short_attr(&attr).to_string(),
+                pname: raw.pname,
+                version: raw.version,
+                description: raw.description,
+            };
+            let ranked = RankedHit {
+                relevance: relevance(&hit, &self.query),
+                hit,
+            };
+
             if hits.len() < MAX_SEARCH_RESULTS {
-                let raw = map.next_value::<RawHit>()?;
-                hits.push(SearchHit {
-                    attr: short_attr(&attr).to_string(),
-                    pname: raw.pname,
-                    version: raw.version,
-                    description: raw.description,
-                });
+                hits.push(ranked);
             } else {
-                let _ = map.next_value::<IgnoredAny>()?;
+                let (worst_index, worst) = hits
+                    .iter()
+                    .enumerate()
+                    .max_by_key(|(_, ranked)| &ranked.relevance)
+                    .expect("bounded result set is not empty");
+                if ranked.relevance < worst.relevance {
+                    hits[worst_index] = ranked;
+                }
             }
         }
-        Ok(hits)
+        hits.sort_by(|a, b| a.relevance.cmp(&b.relevance));
+        Ok(hits.into_iter().map(|ranked| ranked.hit).collect())
     }
+}
+
+fn ranking_term(query: &str) -> String {
+    let query = query.trim();
+    let query = query.strip_prefix('^').unwrap_or(query);
+    query.strip_suffix('$').unwrap_or(query).to_lowercase()
+}
+
+fn relevance(hit: &SearchHit, query: &str) -> Relevance {
+    let attr = hit.attr.to_lowercase();
+    let pname = hit.pname.to_lowercase();
+    let description = hit.description.to_lowercase();
+    let names = [&pname, &attr];
+
+    let (tier, position) = if query.is_empty() {
+        (6, usize::MAX)
+    } else if names.iter().any(|name| name.as_str() == query) {
+        (0, 0)
+    } else if names.iter().any(|name| name.starts_with(query)) {
+        (1, 0)
+    } else if let Some(position) = names
+        .iter()
+        .filter_map(|name| token_position(name, query))
+        .min()
+    {
+        (2, position)
+    } else if let Some(position) = names.iter().filter_map(|name| name.find(query)).min() {
+        (3, position)
+    } else if let Some(position) = token_position(&description, query) {
+        (4, position)
+    } else if let Some(position) = description.find(query) {
+        (5, position)
+    } else {
+        (6, usize::MAX)
+    };
+
+    Relevance {
+        tier,
+        position,
+        name_len: pname.chars().count(),
+        name: pname,
+    }
+}
+
+fn token_position(haystack: &str, needle: &str) -> Option<usize> {
+    haystack
+        .match_indices(needle)
+        .find_map(|(position, matched)| {
+            let before = haystack[..position].chars().next_back();
+            let after = haystack[position + matched.len()..].chars().next();
+            let starts_token = before.is_none_or(|ch| !ch.is_alphanumeric());
+            let ends_token = after.is_none_or(|ch| !ch.is_alphanumeric());
+            (starts_token && ends_token).then_some(position)
+        })
 }
 
 fn short_attr(full: &str) -> &str {
@@ -235,25 +317,78 @@ mod tests {
         }
         json.push('}');
 
-        let hits = parse_hits(json.as_bytes()).unwrap();
+        let hits = parse_hits(json.as_bytes(), "pkg").unwrap();
 
         assert_eq!(hits.len(), MAX_SEARCH_RESULTS);
         assert_eq!(hits[0].attr, "pkg0");
-        assert_eq!(
-            hits[MAX_SEARCH_RESULTS - 1].attr,
-            format!("pkg{}", MAX_SEARCH_RESULTS - 1)
-        );
     }
 
     #[test]
     fn parse_hits_accepts_missing_description() {
         let hits = parse_hits(
             br#"{"legacyPackages.x86_64-linux.ripgrep":{"pname":"ripgrep","version":"14.1.1"}}"#,
+            "ripgrep",
         )
         .unwrap();
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].attr, "ripgrep");
         assert_eq!(hits[0].description, "");
+    }
+
+    #[test]
+    fn exact_match_displaces_early_weak_matches() {
+        let mut json = String::from("{");
+        for i in 0..MAX_SEARCH_RESULTS {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&format!(
+                r#""legacyPackages.x86_64-linux.weak{i}":{{"pname":"weak{i}","version":"1.0","description":"A tool written in Go"}}"#
+            ));
+        }
+        json.push_str(
+            r#", "legacyPackages.x86_64-linux.go":{"pname":"go","version":"1.24","description":"The Go compiler"}}"#,
+        );
+        json.push('}');
+
+        let hits = parse_hits(json.as_bytes(), "go").unwrap();
+
+        assert_eq!(hits.len(), MAX_SEARCH_RESULTS);
+        assert_eq!(hits[0].pname, "go");
+        assert_eq!(
+            hits.iter()
+                .filter(|hit| hit.pname.starts_with("weak"))
+                .count(),
+            MAX_SEARCH_RESULTS - 1
+        );
+    }
+
+    #[test]
+    fn ranks_name_matches_before_description_matches() {
+        let hits = parse_hits(
+            br#"{
+                "legacyPackages.x86_64-linux.air":{"pname":"air","version":"1","description":"Live reload for Go apps"},
+                "legacyPackages.x86_64-linux.go-tools":{"pname":"go-tools","version":"1","description":"Developer tools"},
+                "legacyPackages.x86_64-linux.go":{"pname":"go","version":"1","description":"Compiler"}
+            }"#,
+            "go",
+        )
+        .unwrap();
+
+        assert_eq!(
+            hits.iter()
+                .map(|hit| hit.pname.as_str())
+                .collect::<Vec<_>>(),
+            ["go", "go-tools", "air"]
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires nix and a configured nixpkgs registry"]
+    async fn live_go_search_ranks_exact_package_first() {
+        let hits = search("nixpkgs", "go").await.expect("live nix search");
+
+        assert_eq!(hits.first().map(|hit| hit.pname.as_str()), Some("go"));
     }
 }

--- a/crates/nixbox-tui/Cargo.toml
+++ b/crates/nixbox-tui/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 description = "Ratatui front-end (search/build views, theming) for the nixbox TUI."
 
 [dependencies]
-nixbox-nix = { path = "../nixbox-nix", version = "0.1.7" }
-nixbox-config = { path = "../nixbox-config", version = "0.1.7" }
+nixbox-nix = { path = "../nixbox-nix", version = "0.1.8" }
+nixbox-config = { path = "../nixbox-config", version = "0.1.8" }
 anyhow = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }

--- a/crates/nixbox-tui/src/app.rs
+++ b/crates/nixbox-tui/src/app.rs
@@ -19,7 +19,10 @@ use nixbox_nix::{
 };
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
 use tui_input::Input;
 
 use serde::{Deserialize, Serialize};
@@ -142,6 +145,7 @@ pub(crate) struct App {
     pub(crate) searching: bool,
     pub(crate) search_task: Option<JoinHandle<()>>,
     pub(crate) build_in_progress: bool,
+    pub(crate) build_cancel: Option<oneshot::Sender<()>>,
     pub(crate) spinner_frame: usize,
     pub(crate) queue: VecDeque<QueuedOp>,
     pub(crate) current_op_label: Option<String>,
@@ -197,6 +201,7 @@ impl App {
             searching: false,
             search_task: None,
             build_in_progress: false,
+            build_cancel: None,
             spinner_frame: 0,
             queue: VecDeque::new(),
             current_op_label: None,

--- a/crates/nixbox-tui/src/handlers.rs
+++ b/crates/nixbox-tui/src/handlers.rs
@@ -11,7 +11,7 @@ use crate::nav::{
     open_channel_edit, toggle_target,
 };
 use crate::ops::{
-    drain_queue, install_selected, migrate_all, migrate_selected, schedule_search,
+    cancel_build, drain_queue, install_selected, migrate_all, migrate_selected, schedule_search,
     uninstall_selected,
 };
 use crate::theme;
@@ -137,7 +137,13 @@ pub(crate) async fn handle_terminal_event(
                 _ => {}
             },
         },
-        Tab::Building | Tab::Queue => match key.code {
+        Tab::Building => match key.code {
+            KeyCode::Char('c') => cancel_build(app),
+            KeyCode::Char('l') => cycle_tab(app),
+            KeyCode::Char('h') => cycle_tab_back(app),
+            _ => {}
+        },
+        Tab::Queue => match key.code {
             KeyCode::Char('l') => cycle_tab(app),
             KeyCode::Char('h') => cycle_tab_back(app),
             _ => {}
@@ -249,6 +255,7 @@ pub(crate) fn handle_app_event(app: &mut App, tx: &mpsc::Sender<AppEvent>, ev: A
                 .take()
                 .unwrap_or_else(|| "build".into());
             app.build_in_progress = false;
+            app.build_cancel = None;
             app.in_progress_op = None;
             match &result {
                 Ok(()) => {
@@ -265,6 +272,28 @@ pub(crate) fn handle_app_event(app: &mut App, tx: &mpsc::Sender<AppEvent>, ev: A
             }
             app.persist();
             drain_queue(app, tx);
+            if !app.visible_tabs().contains(&app.tab) {
+                app.tab = Tab::Search;
+            }
+        }
+        AppEvent::Build(BuildEvent::Cancelled) => {
+            let label = app
+                .current_op_label
+                .take()
+                .unwrap_or_else(|| "build".into());
+            app.build_in_progress = false;
+            app.build_cancel = None;
+            app.in_progress_op = None;
+            app.status = if app.queue.is_empty() {
+                format!("{} cancelled.", label)
+            } else {
+                format!(
+                    "{} cancelled; {} queued operation(s) paused.",
+                    label,
+                    app.queue.len()
+                )
+            };
+            app.persist();
             if !app.visible_tabs().contains(&app.tab) {
                 app.tab = Tab::Search;
             }

--- a/crates/nixbox-tui/src/ops.rs
+++ b/crates/nixbox-tui/src/ops.rs
@@ -10,7 +10,7 @@ use nixbox_nix::{
     manifest::{ImportStatus, ManagedFile, ensure_imported},
     scan::{ScanTarget, remove_from_source},
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 
 use crate::app::{App, AppEvent, InstalledCursor, QueuedOp, Tab};
@@ -106,6 +106,8 @@ pub(crate) fn spawn_rebuild(
     action_label: String,
 ) {
     app.build_in_progress = true;
+    let (cancel_tx, mut cancel_rx) = oneshot::channel();
+    app.build_cancel = Some(cancel_tx);
     app.current_op_label = Some(action_label.clone());
     app.in_progress_op = Some(InProgress {
         scope,
@@ -134,7 +136,16 @@ pub(crate) fn spawn_rebuild(
                 // If the flake doesn't expose a standalone `homeConfigurations.<user>`
                 // output, the user wires home-manager in as a NixOS module — apply
                 // the change via `nixos-rebuild` instead.
-                let (c, a) = if flake_has_home_configuration(&config_dir).await {
+                let has_home_configuration = tokio::select! {
+                    has_home = flake_has_home_configuration(&config_dir) => has_home,
+                    _ = &mut cancel_rx => {
+                        let _ = build_tx.send(BuildEvent::Cancelled).await;
+                        drop(build_tx);
+                        let _ = forwarder.await;
+                        return;
+                    }
+                };
+                let (c, a) = if has_home_configuration {
                     home_manager_switch_cmd(&config_dir)
                 } else {
                     let _ = app_tx
@@ -162,7 +173,7 @@ pub(crate) fn spawn_rebuild(
                 )
             }
         };
-        if let Err(e) = rebuild(cmd, &args, build_tx.clone()).await {
+        if let Err(e) = rebuild(cmd, &args, build_tx.clone(), cancel_rx).await {
             let _ = build_tx
                 .send(BuildEvent::Finished(Err(e.to_string())))
                 .await;
@@ -170,6 +181,18 @@ pub(crate) fn spawn_rebuild(
         drop(build_tx);
         let _ = forwarder.await;
     });
+}
+
+pub(crate) fn cancel_build(app: &mut App) {
+    if !app.build_in_progress {
+        return;
+    }
+    let Some(cancel) = app.build_cancel.take() else {
+        return;
+    };
+    if cancel.send(()).is_ok() {
+        app.status = "Cancelling build...".into();
+    }
 }
 
 pub(crate) fn drain_queue(app: &mut App, tx: &mpsc::Sender<AppEvent>) {
@@ -537,5 +560,20 @@ mod tests {
         assert!(app.searching);
         assert_eq!(app.latest_query, "ripgrep");
         assert!(app.search_task.is_some());
+    }
+
+    #[tokio::test]
+    async fn cancel_build_signals_active_rebuild() {
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let mut app = test_app();
+        app.build_in_progress = true;
+        app.build_cancel = Some(cancel_tx);
+
+        cancel_build(&mut app);
+
+        cancel_rx.await.expect("build should be signalled");
+        assert!(app.build_cancel.is_none());
+        assert!(app.build_in_progress);
+        assert_eq!(app.status, "Cancelling build...");
     }
 }

--- a/crates/nixbox-tui/src/ui/bars.rs
+++ b/crates/nixbox-tui/src/ui/bars.rs
@@ -115,6 +115,7 @@ fn context_keys(app: &App) -> &'static str {
                     "j/k nav  h/l tabs  d uninstall  m migrate  M migrate all  i filter  esc quit"
                 }
             },
+            Tab::Building if app.build_in_progress => "c cancel build  h/l tabs  esc quit",
             Tab::Building => "h/l tabs  esc quit",
             Tab::Queue => "h/l tabs  esc quit",
         },

--- a/crates/nixbox/Cargo.toml
+++ b/crates/nixbox/Cargo.toml
@@ -16,9 +16,9 @@ name = "nixbox"
 path = "src/main.rs"
 
 [dependencies]
-nixbox-tui = { path = "../nixbox-tui", version = "0.1.7" }
-nixbox-nix = { path = "../nixbox-nix", version = "0.1.7" }
-nixbox-config = { path = "../nixbox-config", version = "0.1.7" }
+nixbox-tui = { path = "../nixbox-tui", version = "0.1.8" }
+nixbox-nix = { path = "../nixbox-nix", version = "0.1.8" }
+nixbox-config = { path = "../nixbox-config", version = "0.1.8" }
 anyhow = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary
- prevent search subprocess pipe deadlocks and rank exact/name matches ahead of weak matches
- add cancellation for active rebuild process groups from the Building tab
- migrate the development environment from a project Flake to devenv
- bump all workspace crates to v0.1.7

## Verification
- `just ci`
- live ignored test confirms searching `go` ranks the exact package first
- subprocess regression test confirms cancellation emits `BuildEvent::Cancelled`